### PR TITLE
fix: cast halfh to int for valid crop coordinates

### DIFF
--- a/mpsfm/extraction/pairwise/models/mast3r.py
+++ b/mpsfm/extraction/pairwise/models/mast3r.py
@@ -99,7 +99,7 @@ def load_images(folder_or_list, size, square_ok=False, verbose=True):
         else:
             halfw, halfh = ((2 * cx) // 16) * 8, ((2 * cy) // 16) * 8
             if not (square_ok) and W == H:
-                halfh = 3 * halfw / 4
+                halfh = int(3 * halfw / 4)
             img = img.crop((cx - halfw, cy - halfh, cx + halfw, cy + halfh))
 
         W2, H2 = img.size
@@ -230,7 +230,7 @@ class Mast3rMatcher(BaseModel):
         cx, cy = W // 2, H // 2
         halfw, halfh = ((2 * cx) // 16) * 8, ((2 * cy) // 16) * 8
         if not (square_ok) and W == H:
-            halfh = 3 * halfw / 4
+            halfh = int(3 * halfw / 4)
         image = image[..., cy - halfh : cy + halfh, cx - halfw : cx + halfw]
         H2, W2 = image.shape[-2:]
         ImgNorm = tvf.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))


### PR DESCRIPTION
## Changes
- Explicitly cast `halfh` to integer when adjusting aspect ratio for non-square crops

## Why
When `square_ok=False` and `W == H`, the calculation `3 * halfw / 4` could produce a float value for `halfh`, causing `Image.crop()` to throw errors due to non-integer coordinates. This explicitly converts the value to an integer to ensure valid crop parameters.

## Impact
Fixes potential runtime errors when processing images requiring aspect ratio adjustments, ensuring valid integer coordinates are used for cropping operations.